### PR TITLE
Add feature to disable crxde sme way to enable it

### DIFF
--- a/cloudformation/ssm-commands-cloudformation.yaml
+++ b/cloudformation/ssm-commands-cloudformation.yaml
@@ -72,6 +72,12 @@ Parameters:
     Description: >-
       The name of the file containing the EnableCrxde SSM command.
 
+  DisableCrxdeIncludeFile:
+    Type: String
+    Default: AEM-DisableCrxde.yaml
+    Description: >-
+      The name of the file containing the DisableCrxde SSM command.
+
   RunAdhocPuppetIncludeFile:
     Type: String
     Default: AEM-RunAdhocPuppet.yaml
@@ -177,6 +183,16 @@ Resources:
           Name: 'AWS::Include'
           Parameters: !Sub '${S3BucketAndPrefix}/${EnableCrxdeIncludeFile}'
 
+  DisableCrxde:
+    Type: AWS::SSM::Document
+    Properties:
+      DocumentType: Command
+      Content:
+        Fn::Transform:
+          Name: 'AWS::Include'
+          Parameters: !Sub '${S3BucketAndPrefix}/${DisableCrxdeIncludeFile}'
+
+
   RunAdhocPuppet:
     Type: AWS::SSM::Document
     Properties:
@@ -226,6 +242,10 @@ Outputs:
   EnableCrxde:
     Description: Document name for Enable Crxde
     Value: !Ref EnableCrxde
+
+  DisableCrxde:
+    Description: Document name for Disable Crxde
+    Value: !Ref DisableCrxde
 
   RunAdhocPuppet:
     Description: Document name for Run Adhoc Puppet

--- a/cloudformation/ssm-commands/AEM-DisableCrxde.yaml
+++ b/cloudformation/ssm-commands/AEM-DisableCrxde.yaml
@@ -1,0 +1,22 @@
+---
+schemaVersion: '2.0'
+description: >-
+  Disable Crxde on instances.
+parameters:
+  executionTimeout:
+    description: >-
+      (Optional) The time in seconds for a command to be completed before it is
+      considered to have failed. Default is 3600 (1 hour). Maximum is 28800 (8
+      hours).
+    type: String
+    allowedPattern: ([1-9][0-9]{0,3})|(1[0-9]{1,4})|(2[0-7][0-9]{1,3})|(28[0-7][0-9]{1,2})|(28800)
+    default: '3600'
+mainSteps:
+  - action: aws:runShellScript
+    name: runShellScript
+    inputs:
+      runCommand:
+        - '. /etc/profile'
+        - '/opt/shinesolutions/aem-tools/disable-crxde.sh'
+      timeoutSeconds: '{{ executionTimeout }}'
+      workingDirectory: /tmp

--- a/lambda/aem_stack_manager.py
+++ b/lambda/aem_stack_manager.py
@@ -224,6 +224,27 @@ def enable_crxde(message, ssm_common_params):
     params.update(details)
     return send_ssm_cmd(params)
 
+def disable_crxde(message, ssm_common_params):
+    target_filter = [
+        {
+            'Name': 'tag:StackPrefix',
+            'Values': [message['stack_prefix']]
+        }, {
+            'Name': 'instance-state-name',
+            'Values': ['running']
+        }, {
+            'Name': 'tag:Component',
+            'Values': [message['details']['component']]
+        }
+    ]
+    # boto3 ssm client does not accept multiple filter for Targets
+    details = {
+        'InstanceIds': instance_ids_by_tags(target_filter),
+        'Comment': 'disable crxde on selected AEM instances by component'
+    }
+    params = ssm_common_params.copy()
+    params.update(details)
+    return send_ssm_cmd(params)
 
 def run_adhoc_puppet(message, ssm_common_params):
     target_filter = [
@@ -365,6 +386,7 @@ method_mapper = {
     'import-package': import_package,
     'promote-author': promote_author,
     'enable-crxde': enable_crxde,
+    'disable-crxde': disable_crxde,
     'run-adhoc-puppet': run_adhoc_puppet
 }
 


### PR DESCRIPTION
Part 4/4

Added the feature to disable crxde the same way to enable it.

Regarding Issue https://github.com/shinesolutions/aem-aws-stack-provisioner/issues/52