### PR TITLE
Add new lambda function for streaming CloudWatch logs to S3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- Add new lambda function for streaming CloudWatch logs to S3
+
 ## 1.3.5 - 2019-08-05
 ### Fixed
 - Fixed passing of wrong parameter type on offline-snapshot [#37]

--- a/lambda/cloudwatch_logs_s3_stream.py
+++ b/lambda/cloudwatch_logs_s3_stream.py
@@ -1,0 +1,65 @@
+# -*- coding: utf8 -*-
+
+"""
+Lambda function to store cloudwatch log streams on S3
+"""
+
+import os
+import boto3
+import json
+import tempfile
+import logging
+import uuid
+from datetime import date
+
+# setting up logger
+logger = logging.getLogger(__name__)
+logger.setLevel(int(os.getenv('LOG_LEVEL', logging.INFO)))
+
+# Set todays date
+today = date.today()
+today_date = today.strftime("%Y/%m/%d")
+
+# Create s3 client connection
+s3 = boto3.client('s3')
+
+def handler(event, ctx) -> None:
+    # reading in config info from either s3 or within bundle
+    bucket = os.getenv('S3_BUCKET')
+    prefix = os.getenv('S3_PREFIX')
+
+    if bucket is not None and prefix is not None:
+        config_file = '/tmp/config.json'
+        s3.download_file(bucket, '{}/config.json'.format(prefix), config_file)
+    else:
+        logger.info('Unable to locate config.json in S3, searching within bundle')
+        config_file = 'config.json'
+
+    # Read configuration file
+    with open(config_file, 'r') as f:
+        content = ''.join(f.readlines()).replace('\n', '')
+        logger.debug('config file: ' + content)
+        config = json.loads(content)
+        cw_stream_s3_config = config['cw_stream_s3']
+        cw_stream_s3_bucket = cw_stream_s3_config['s3-bucket-cw-stream']
+        cw_stream_s3_prefix = cw_stream_s3_config['s3-prefix-cw-stream']
+
+    # Generate random uuid
+    message_uuid = str(uuid.uuid4())
+
+    # Set s3 destionation path
+    s3_destination = cw_stream_s3_prefix + '/' + today_date + '/' + message_uuid
+
+    awslogs = event['awslogs']
+    awslogs_data = awslogs['data']
+
+    with tempfile.NamedTemporaryFile() as tmp_file:
+        tmp_file_name = tmp_file.name
+        with open(tmp_file_name, 'w') as file:
+            file.write(awslogs_data)
+
+        s3.upload_file(
+            Bucket = cw_stream_s3_bucket,
+            Filename=tmp_file_name,
+            Key=s3_destination
+        )


### PR DESCRIPTION
Add new lambda function for streaming CloudWatch logs to S3.

This PR includes a new Lambda function which consumes Cloudwatchlogstreams and uploads them to 

`s3://S3_BUCKET/S3-PREFIX/YEAR/MONTH/DAY/UUID`

Cloudwatch sends logstreams in base64 encoded gzip which this lambda function uploads it 1:1 to S3 without modifying them.