### PR TITLE
Fix/aem offline snapshot asg processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add new process to suspend/resume ASG process `AlarmNotification` while aem_offline_snapshot lambda is running [shinesolutions/aem-aws-stack-builder#295]
 
+### Fixed
+- Fix print of wrong instance count while updating publish-dispatcher ASG.
+
 
 ## 1.4.0 - 2019-09-17
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- Add new process to suspend/resume ASG process `AlarmNotification` while aem_offline_snapshot lambda is running [shinesolutions/aem-aws-stack-builder#295]
+
+
 ## 1.4.0 - 2019-09-17
 ### Added
 - Add new lambda function for streaming CloudWatch logs to S3

--- a/lambda/aem_offline_snapshot.py
+++ b/lambda/aem_offline_snapshot.py
@@ -189,9 +189,10 @@ def manage_autoscaling_standby(stack_prefix, action, **kwargs):
     asg_min_size = asg_dcrb['AutoScalingGroups'][0]['MinSize']
     asg_max_size = asg_dcrb['AutoScalingGroups'][0]['MaxSize']
 
+    min_size = max(asg_min_size - len(instance_ids), 0)
+
     # manage the instances standby mode
     if action == 'enter':
-        print('[{}] Start updating ASG {} to 0 instances ...'.format(stack_prefix, asg_name))
         print('[{}] Start updating ASG {} to suspend AlarmNotification processes ...'.format(stack_prefix, asg_name))
         autoscaling.suspend_processes(
             AutoScalingGroupName=asg_name,
@@ -201,11 +202,12 @@ def manage_autoscaling_standby(stack_prefix, action, **kwargs):
         )
         print('[{}] Finished updating ASG {} to suspend AlarmNotification processes ...'.format(stack_prefix, asg_name))
 
+        print('[{}] Start updating ASG {} to {} instances ...'.format(stack_prefix, asg_name, min_size))
         autoscaling.update_auto_scaling_group(
             AutoScalingGroupName=asg_name,
-            MinSize=max(asg_min_size - len(instance_ids), 0)
+            MinSize=min_size
         )
-        print('[{}] Finished updating ASG {} to 0 instances.'.format(stack_prefix, asg_name))
+        print('[{}] Finished updating ASG {} to {} instances.'.format(stack_prefix, asg_name, min_size))
 
         print('[{}] Start entering instance {} into standby in ASG {} ...'.format(stack_prefix, instance_ids, asg_name))
         autoscaling.enter_standby(

--- a/lambda/aem_offline_snapshot.py
+++ b/lambda/aem_offline_snapshot.py
@@ -192,6 +192,15 @@ def manage_autoscaling_standby(stack_prefix, action, **kwargs):
     # manage the instances standby mode
     if action == 'enter':
         print('[{}] Start updating ASG {} to 0 instances ...'.format(stack_prefix, asg_name))
+        print('[{}] Start updating ASG {} to suspend AlarmNotification processes ...'.format(stack_prefix, asg_name))
+        autoscaling.suspend_processes(
+            AutoScalingGroupName=asg_name,
+            ScalingProcesses=[
+                'AlarmNotification',
+            ]
+        )
+        print('[{}] Finished updating ASG {} to suspend AlarmNotification processes ...'.format(stack_prefix, asg_name))
+
         autoscaling.update_auto_scaling_group(
             AutoScalingGroupName=asg_name,
             MinSize=max(asg_min_size - len(instance_ids), 0)
@@ -220,6 +229,14 @@ def manage_autoscaling_standby(stack_prefix, action, **kwargs):
         )
         print('[{}] Finished updating ASG {} to {} instances.'.format(stack_prefix, asg_name, asg_max_size))
 
+        print('[{}] Start updating ASG {} to allow AlarmNotification processes again ...'.format(stack_prefix, asg_name))
+        autoscaling.resume_processes(
+            AutoScalingGroupName=asg_name,
+            ScalingProcesses=[
+                'AlarmNotification',
+            ]
+        )
+        print('[{}] Finished updating ASG {} to allow AlarmNotification processes again ...'.format(stack_prefix, asg_name))
 
 def retrieve_tag_value(instance_id, tag_key):
     response = boto3.client('ec2').describe_tags(


### PR DESCRIPTION
Fix/aem offline snapshot asg processes


This PR includes following changes for the lambda function `aem_offline_snapshot.py`:

* While updating the ASG at the beginning of the offline-snapshot process, suspend also the scaling process `AlarmNotififcation`.
This is needed to avoid any scaling event triggered by the configured ScalingPolicy for `publish-dispatcher` while the offline-snapshot process is running.  [shinesolutions/aem-aws-stack-builder#295]

* While updating the ASg at the end of the offline-snapshot process, reusme the supended scaling process `AlarmNotification`. [shinesolutions/aem-aws-stack-builder#295]

* Fix printing of wrong information while updating the publish-dispatcher ASG.